### PR TITLE
overlay: Exempt MediaTek ImsService from location indicators

### DIFF
--- a/overlay/common/frameworks/base/core/res/res/values/config.xml
+++ b/overlay/common/frameworks/base/core/res/res/values/config.xml
@@ -49,6 +49,8 @@
         <item>com.qualcomm.qti.cne</item>
         <!-- ImsService -->
         <item>com.shannon.imsservice</item>
+        <!-- MediaTek ImsService -->
+        <item>com.mediatek.ims</item>
     </string-array>
 
     <bool name="config_cellBroadcastAppLinks">true</bool>


### PR DESCRIPTION
* Mtk ImsService checks for location data to register ims, which constantly triggers the location indicator.

Change-Id: I1b78ffd788129902a23eba844044f3afbdfe46ff