### PR TITLE
overlay: move desktop mode config from tablet to common

### DIFF
--- a/overlay/common/frameworks/base/core/res/res/values/config.xml
+++ b/overlay/common/frameworks/base/core/res/res/values/config.xml
@@ -77,6 +77,9 @@
          it should be disabled in that locale's resources. -->
     <bool name="config_buttonTextAllCaps">false</bool>
 
+    <!-- Whether desktop mode is supported on the current device  -->
+    <bool name="config_isDesktopModeSupported">true</bool>
+
     <!-- List of packages that can use the Conversation space for their category messages
     notifications until they target R -->
     <string-array name="config_notificationMsgPkgsAllowedAsConvos" translatable="false">

--- a/overlay/tablet/frameworks/base/core/res/res/values/config.xml
+++ b/overlay/tablet/frameworks/base/core/res/res/values/config.xml
@@ -23,7 +23,4 @@
 
     <!-- Whether to enable glanceable hub features on this device. -->
     <bool name="config_glanceableHubEnabled">true</bool>
-
-    <!-- Whether desktop mode is supported on the current device  -->
-    <bool name="config_isDesktopModeSupported">true</bool>
 </resources>


### PR DESCRIPTION
Some targets support video out from their usb port, this would also enable the new UI for scrcpy --new-display flag.

Change-Id: Ia87e58722ec3766dfdc19bb9759a96f69eeaba32